### PR TITLE
Fix wrong ivar referenced on join the server thread

### DIFF
--- a/spec/integrations/server_spec.rb
+++ b/spec/integrations/server_spec.rb
@@ -66,7 +66,7 @@ describe "Lite Cable server", :async do
 
   after(:all) do
     @server&.stop(true)
-    @t&.join
+    @server_t&.join
   end
 
   let(:cookies) { "user=john" }


### PR DESCRIPTION
In `spec/integrations/server_spec.rb` we are reference wrong instance variable `@t` in attempt to "join" the thread with server that we run in `before(:all)` hook. This PR fixes this.