### PR TITLE
fix: `bundle exec rake` and example app

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.5", "2.6", "2.7", "3.0", "truffleruby"]
+        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "truffleruby"]
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1

--- a/examples/sinatra/app.rb
+++ b/examples/sinatra/app.rb
@@ -9,7 +9,7 @@ class App < Sinatra::Application # :nodoc:
   set :public_folder, "assets"
 
   enable :sessions
-  set :session_secret, "my_secrets"
+  set :session_secret, "secret_key_with_size_of_32_bytes_dff054b19c2de43fc406f251376ad40"
 
   get "/" do
     if session[:user]

--- a/examples/sinatra/chat.rb
+++ b/examples/sinatra/chat.rb
@@ -29,7 +29,7 @@ module Chat
     end
 
     def speak(data)
-      LiteCable.broadcast "chat_#{chat_id}", user: user, message: data["message"], sid: sid
+      LiteCable.broadcast "chat_#{chat_id}", { user: user, message: data["message"], sid: sid }
     end
 
     private

--- a/examples/sinatra/chat.rb
+++ b/examples/sinatra/chat.rb
@@ -29,7 +29,7 @@ module Chat
     end
 
     def speak(data)
-      LiteCable.broadcast "chat_#{chat_id}", { user: user, message: data["message"], sid: sid }
+      LiteCable.broadcast "chat_#{chat_id}", {user: user, message: data["message"], sid: sid}
     end
 
     private

--- a/lib/lite_cable/anycable.rb
+++ b/lib/lite_cable/anycable.rb
@@ -23,7 +23,6 @@ module LiteCable # :nodoc:
           @request ||= Rack::Request.new(socket.env)
         end
 
-        # rubocop: disable Metrics/MethodLength
         def handle_channel_command(identifier, command, data)
           channel = subscriptions.add(identifier, false)
           case command
@@ -45,7 +44,6 @@ module LiteCable # :nodoc:
           close
           false
         end
-        # rubocop: enable Metrics/MethodLength
       end
     end
   end

--- a/lib/lite_cable/broadcast_adapters.rb
+++ b/lib/lite_cable/broadcast_adapters.rb
@@ -6,7 +6,6 @@ module LiteCable
   module BroadcastAdapters # :nodoc:
     module_function
 
-    # rubocop: disable Metrics/AbcSize, Metrics/MethodLength
     def lookup_adapter(args)
       adapter, options = Array(args)
       path_to_adapter = "lite_cable/broadcast_adapters/#{adapter}"
@@ -30,6 +29,5 @@ module LiteCable
 
       BroadcastAdapters.const_get(adapter_class_name, false).new(**(options || {}))
     end
-    # rubocop: enable Metrics/AbcSize, Metrics/MethodLength
   end
 end

--- a/lib/lite_cable/server/client_socket/base.rb
+++ b/lib/lite_cable/server/client_socket/base.rb
@@ -64,7 +64,6 @@ module LiteCable
           @error_handlers << block
         end
 
-        # rubocop: disable Metrics/MethodLength
         def listen
           keepalive
           Thread.new do
@@ -74,7 +73,7 @@ module LiteCable
               each_frame do |data|
                 @message_handlers.each do |h|
                   h.call(data)
-                rescue => e # rubocop: disable Style/RescueStandardError
+                rescue => e
                   log(:error, "Socket receive failed: #{e}")
                   @error_handlers.each { |eh| eh.call(e, data) }
                   close if close_on_error
@@ -85,7 +84,6 @@ module LiteCable
             end
           end
         end
-        # rubocop: enable Metrics/MethodLength
 
         def close
           return unless @active
@@ -116,7 +114,7 @@ module LiteCable
           frame = WebSocket::Frame::Outgoing::Server.new(version: version, type: :close, code: 1000)
           @socket.write(frame.to_s) if frame.supported?
           @socket.close
-        rescue IOError, Errno::EPIPE, Errno::ETIMEDOUT # rubocop:disable Lint/HandleExceptions
+        rescue IOError, Errno::EPIPE, Errno::ETIMEDOUT
           # already closed
         end
 

--- a/lib/lite_cable/server/client_socket/base.rb
+++ b/lib/lite_cable/server/client_socket/base.rb
@@ -135,7 +135,7 @@ module LiteCable
         def each_frame
           framebuffer = WebSocket::Frame::Incoming::Server.new(version: version)
 
-          while IO.select([socket])
+          while socket.wait_readable
             data = socket.respond_to?(:recv) ? socket.recv(2000) : socket.readpartial(2000)
             break if data.empty?
 

--- a/lib/lite_cable/server/heart_beat.rb
+++ b/lib/lite_cable/server/heart_beat.rb
@@ -23,7 +23,6 @@ module LiteCable
         @stopped = true
       end
 
-      # rubocop: disable Metrics/MethodLength
       def run
         Thread.new do
           Thread.current.abort_on_exception = true
@@ -41,7 +40,6 @@ module LiteCable
           end
         end
       end
-      # rubocop: enable Metrics/MethodLength
 
       private
 

--- a/spec/integrations/server_spec.rb
+++ b/spec/integrations/server_spec.rb
@@ -55,11 +55,10 @@ describe "Lite Cable server", :async do
   before(:all) do
     @server = ::Puma::Server.new(
       LiteCable::Server::Middleware.new(nil, connection_class: ServerTest::Connection),
-      ::Puma::Events.strings
+      nil,
+      { min_threads: 1, max_threads: 4 }
     )
     @server.add_tcp_listener "127.0.0.1", 3099
-    @server.min_threads = 1
-    @server.max_threads = 4
 
     @server_t = Thread.new { @server.run.join }
   end

--- a/spec/integrations/server_spec.rb
+++ b/spec/integrations/server_spec.rb
@@ -56,7 +56,7 @@ describe "Lite Cable server", :async do
     @server = ::Puma::Server.new(
       LiteCable::Server::Middleware.new(nil, connection_class: ServerTest::Connection),
       nil,
-      { min_threads: 1, max_threads: 4 }
+      {min_threads: 1, max_threads: 4}
     )
     @server.add_tcp_listener "127.0.0.1", 3099
 

--- a/spec/lite_cable/connection/base_spec.rb
+++ b/spec/lite_cable/connection/base_spec.rb
@@ -72,7 +72,7 @@ describe TestBaseConnection do
 
   describe "#handle_command" do
     it "runs subscriptions #execute_command" do
-      expect(subject.subscriptions).to receive(:execute_command).with("command" => "test")
+      expect(subject.subscriptions).to receive(:execute_command).with({ "command" => "test" })
       subject.handle_command('{"command":"test"}')
     end
   end

--- a/spec/lite_cable/connection/base_spec.rb
+++ b/spec/lite_cable/connection/base_spec.rb
@@ -72,7 +72,7 @@ describe TestBaseConnection do
 
   describe "#handle_command" do
     it "runs subscriptions #execute_command" do
-      expect(subject.subscriptions).to receive(:execute_command).with({ "command" => "test" })
+      expect(subject.subscriptions).to receive(:execute_command).with({"command" => "test"})
       subject.handle_command('{"command":"test"}')
     end
   end


### PR DESCRIPTION
## Summary

Fixes #71 

## Changes

- [x] Added 3.1 Ruby version to CI
- [x] Removed excessive `rubocop:disable` comments
- [x] **!!!** Use of `IO#wait_readable` instead of `IO.select` ([rubocop warning](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/IncompatibleIoSelectWithFiberScheduler))
- [x] Updated `Puma::Server.new` call within specs to work with puma v6 (the version from Gemfile.lock)
- [x] Updated failing spec (keyword arguments vs options hash)
- [x] Fixed errors within example app

### Checklist

- [ ] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated Readme

Manually checked 2.5, seems ok ¯\_(ツ)_/¯